### PR TITLE
Define strict mode in the nodejs api js

### DIFF
--- a/www/nodejs_apis.js
+++ b/www/nodejs_apis.js
@@ -1,4 +1,5 @@
 // Bridge between the Cordova UI and the NodeJS plugin
+'use strict';
 
 class Channel {};
 


### PR DESCRIPTION
**Edit: Moved to https://github.com/janeasystems/nodejs-mobile/issues/22 (according to "Reporting Issues" in the README)**

Hi,

thanks for your awesome work on nodejs-mobile!

I noticed when adding the plugin to an android platform, building it and running it on a device, the console logs the following error messages:

```
Uncaught SyntaxError: Block-scoped declarations (let, const, function, class) not yet supported outside strict mode plugins/nodejs-mobile-cordova/www/nodejs_apis.js:5
Uncaught Error: Module nodejs-mobile-cordova.nodejs does not exist. cordova.js:1470
```

To solve this it's necessary to put `www/nodejs_apis.js` into strict mode. With this change the plugin loads and logs the welcome message as expected.

```
NodeJs Engine Started
[cordova] received: Replying to this message: Hello from Cordova! index.js:32
```

Hope this helps.

Best regards