### PR TITLE
Fix for #48. Update plugin.xml for cordova 8.0.0

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -57,7 +57,7 @@
       </feature>
     </config-file>
 
-    <config-file target="AndroidManifest.xml" parent="/manifest">
+    <config-file target="app/src/main/AndroidManifest.xml" parent="/manifest">
       <uses-permission android:name="android.permission.INTERNET" />
       <uses-permission android:name="android.permission.WRITE_INTERNAL_STORAGE" />
       <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />


### PR DESCRIPTION
Fix for https://github.com/janeasystems/nodejs-mobile/issues/48

Cordova 7.0.0 changes the android project structure. It means plugin.xml android config-file target needs to change from target="AndroidManifest.xml" to target="app/src/main/AndroidManifest.xml".

Reference: https://cordova.apache.org/announcements/2017/12/04/cordova-android-7.0.0.html