### PR TITLE
plugin: new channel API

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,11 +39,8 @@ These methods can be called from the Cordova javascript code directly:
 
 > `nodejs.channel.setListener(callback)` is equivalent to `nodejs.channel.on('message',callback)` and `nodejs.channel.send(msg)` is equivalent to `nodejs.channel.post('message',msg)`. They are maintained for backward compatibility purposes.
 
-### nodejs.start
+### nodejs.start(scriptFileName, callback [, options])
 
-```js
-  nodejs.start(scriptFileName, callback [, options]);
-```
 | Param | Type |
 | --- | --- |
 | scriptFileName | <code>string</code> |
@@ -52,11 +49,8 @@ These methods can be called from the Cordova javascript code directly:
 
 Starts the nodejs-mobile runtime thread with a file inside the `nodejs-project` directory.
 
-### nodejs.startWithScript
+### nodejs.startWithScript(scriptBody, callback [, options])
 
-```js
-  nodejs.startWithScript(scriptBody, callback [, options]);
-```
 | Param | Type |
 | --- | --- |
 | scriptBody | <code>string</code> |
@@ -65,11 +59,8 @@ Starts the nodejs-mobile runtime thread with a file inside the `nodejs-project` 
 
 Starts the nodejs-mobile runtime thread with a script body.
 
-### nodejs.channel.on
+### nodejs.channel.on(event, callback)
 
-```js
-  nodejs.channel.on(event, callback);
-```
 | Param | Type |
 | --- | --- |
 | event | <code>string</code> |
@@ -77,11 +68,8 @@ Starts the nodejs-mobile runtime thread with a script body.
 
 Registers a callback for user-defined events raised from the nodejs-mobile side.
 
-### nodejs.channel.post
+### nodejs.channel.post(event, message)
 
-```js
-  nodejs.channel.post(event, message);
-```
 | Param | Type |
 | --- | --- |
 | event | <code>string</code> |
@@ -89,11 +77,8 @@ Registers a callback for user-defined events raised from the nodejs-mobile side.
 
 Raises a user-defined event on the nodejs-mobile side.
 
-### nodejs.channel.setListener
+### nodejs.channel.setListener(listenerCallback)
 
-```js
-  nodejs.channel.setListener(listenerCallback);
-```
 | Param | Type |
 | --- | --- |
 | listenerCallback | <code>[function](#cordova.channelCallback)</code> |
@@ -101,11 +86,8 @@ Raises a user-defined event on the nodejs-mobile side.
 Registers a callback for 'message' events raised from the nodejs-mobile side.
 It is an alias for `nodejs.channel.on('message', listenerCallback);`.
 
-### nodejs.channel.send
+### nodejs.channel.send(message)
 
-```js
-  nodejs.channel.send(message);
-```
 | Param | Type |
 | --- | --- |
 | message | any JS type that can be serialized with `JSON.stringify` and deserialized with `JSON.parse` |
@@ -132,14 +114,13 @@ The following methods can be called from the Node javascript code through the `c
 - `cordova.channel.on`
 - `cordova.channel.post`
 - `cordova.channel.send`
+- `cordova.app.on`
+- `cordova.app.datadir`
 
 > `cordova.channel.send(msg)` is equivalent to `cordova.channel.post('message',msg)`. It is maintained for backward compatibility purposes.
 
-### cordova.channel.on
+### cordova.channel.on(event, callback)
 
-```js
-  cordova.channel.on(event, callback);
-```
 | Param | Type |
 | --- | --- |
 | event | <code>string</code> |
@@ -152,11 +133,8 @@ Registers a callback for user-defined events raised from the cordova side.
 >   cordova.channel.on('message', listenerCallback);
 > ```
 
-### cordova.channel.post
+### cordova.channel.post(event, message)
 
-```js
-  cordova.channel.post(event, message);
-```
 | Param | Type |
 | --- | --- |
 | event | <code>string</code> |
@@ -164,17 +142,37 @@ Registers a callback for user-defined events raised from the cordova side.
 
 Raises a user-defined event on the cordova side.
 
-### cordova.channel.send
+### cordova.channel.send(message)
 
-```
- cordova.channel.send(message);
-```
 | Param | Type |
 | --- | --- |
 | message | any JS type that can be serialized with `JSON.stringify` and deserialized with `JSON.parse` |
 
 Raises a 'message' event on the cordova side.
 It is an alias for `cordova.channel.post('message', message);`.
+
+### cordova.app.on(event, callback)
+
+| Param | Type |
+| --- | --- |
+| event | <code>string</code> |
+| callback | <code>function</code> |
+
+Registers callbacks for App events.
+Currently supports the 'pause' and 'resume' events, which are raised automatically when the app switches to the background/foreground.
+
+```js
+cordova.app.on('pause', () => {
+  console.log('[node] app paused.');
+});
+cordova.app.on('resume', () => {
+  console.log('[node] app resumed.');
+});
+```
+
+### cordova.app.datadir()
+
+Returns a writable path used for persistent data storage in the application. Its value corresponds to `NSDocumentDirectory` on iOS and `FilesDir` on Android.
 
 <a name="cordova.channelCallback"></a>
 ### Channel callback: <code>function(arg)</code>

--- a/install/nodejs-mobile-cordova-assets/builtin_modules/cordova-bridge/index.js
+++ b/install/nodejs-mobile-cordova-assets/builtin_modules/cordova-bridge/index.js
@@ -1,17 +1,152 @@
+'use strict';
+
 const EventEmitter = require('events');
 const NativeBridge = process.binding('cordova_bridge');
 
-class ChannelEmitter extends EventEmitter { }
-ChannelEmitter.prototype.send = function (msg) {
-  NativeBridge.send(msg);
+/**
+ * Built-in events channel to exchange events between the Cordova app
+ * and the Node.js app. It allows to emit user defined event types with
+ * an optional message.
+ */
+const EVENT_CHANNEL = '_EVENTS_';
+
+/**
+ * Built-in, one-way event channel reserved for sending events from
+ * the Cordova plug-in native layer to the Node.js app.
+ */
+const SYSTEM_CHANNEL = '_SYSTEM_';
+
+/**
+ * This classes is defined in www/nodejs-apis.js as well.
+ * Any change made here should be ported to www/nodejs-apis.js too.
+ * The MessageCodec class provides two static methods to serialize/deserialize
+ * the data sent through the events channel.
+*/
+class MessageCodec {
+  // This is a 'private' constructor, should only be used by this class
+  // static methods.
+  constructor(_event, _payload) {
+    this.event = _event;
+    this.payload = JSON.stringify(_payload);
+  };
+
+  // Serialize the message payload and the message.
+  static serialize(event, payload) {
+    const envelope = new MessageCodec(event, payload);
+    // Return the serialized message, that can be sent through a channel.
+    return JSON.stringify(envelope);
+  };
+
+  // Deserialize the message and the message payload.
+  static deserialize(message) {
+    var envelope = JSON.parse(message);
+    if (envelope.payload !== undefined) {
+      envelope.payload = JSON.parse(envelope.payload);
+    }
+    return envelope;
+  };
 };
 
-const channel = new ChannelEmitter();
+/**
+ * Channel super class.
+ */
+class ChannelSuper extends EventEmitter {
+  constructor(name) {
+    super();
+    this.name = name;
+    // Renaming the 'emit' method to 'emitLocal' is not strictly needed, but
+    // it is useful to clarify that 'emitting' on this object has a local
+    // scope: it emits the event on the Cordova side only, it doesn't send
+    // the event to Node.
+    this.emitLocal = this.emit;
+    delete this.emit;
+  };
 
-NativeBridge.setListener(function (msg) {
-  setImmediate( () => {
-    channel.emit('message', msg);
-  });
-});
+  emitWrapper(type, msg) {
+    const _this = this;
+    setImmediate( () => {
+      if (msg) {
+        _this.emitLocal(type, msg);
+      } else {
+        _this.emitLocal(type);
+      }
+     });
+  };
+};
 
-exports.channel = channel;
+/**
+ * Events channel class that supports user defined event types with
+ * an optional message. Allows to send any serializable
+ * JavaScript object supported by 'JSON.stringify()'.
+ * Sending functions is not currently supported.
+ * Includes the previously available 'send' method for 'message' events.
+ */
+class EventChannel extends ChannelSuper {
+  post(event, msg) {
+    NativeBridge.sendMessage(this.name, MessageCodec.serialize(event, msg));
+  };
+
+  // Posts a 'message' event, to be backward compatible with old code.
+  send(msg) {
+    this.post('message',msg);
+  };
+
+  processData(data) {
+    // The data contains the serialized message envelope.
+    var envelope = MessageCodec.deserialize(data);
+    this.emitWrapper(envelope.event, envelope.payload);
+  };
+};
+
+/**
+ * System channel class.
+ * Emit pause/resume events when the app goes to background/foreground.
+ */
+class SystemChannel extends ChannelSuper {
+  processData(data) {
+    // The data is the event.
+    this.emitWrapper(data);
+  };
+};
+
+/**
+ * Manage the registered channels to emit events/messages received by the
+ * Cordova app or by the Cordova plugin itself (i.e. the system channel).
+ */
+var channels = {};
+
+/*
+ * This method is invoked by the native code when an event/message is received
+ * from the Cordova app.
+ */
+function bridgeListener(channelName, data) {
+  if (channels.hasOwnProperty(channelName)) {
+    channels[channelName].processData(data);
+  } else {
+    console.error('ERROR: Channel not found:', channelName);
+  }
+};
+
+/*
+ * The bridge's native code processes each channel's messages in a dedicated
+ * per-channel queue, therefore each channel needs to be registered within
+ * the native code.
+ */
+function registerChannel(channel) {
+  channels[channel.name] = channel;
+  NativeBridge.registerChannel(channel.name, bridgeListener);
+};
+
+/**
+ * Module exports.
+ */
+const systemChannel = new SystemChannel(SYSTEM_CHANNEL);
+registerChannel(systemChannel);
+
+const eventChannel = new EventChannel(EVENT_CHANNEL);
+registerChannel(eventChannel);
+
+module.exports = exports = {
+  app: systemChannel,
+  channel: eventChannel
+};

--- a/install/nodejs-mobile-cordova-assets/builtin_modules/cordova-bridge/index.js
+++ b/install/nodejs-mobile-cordova-assets/builtin_modules/cordova-bridge/index.js
@@ -40,7 +40,7 @@ class MessageCodec {
   // Deserialize the message and the message payload.
   static deserialize(message) {
     var envelope = JSON.parse(message);
-    if (envelope.payload !== undefined) {
+    if (typeof envelope.payload !== 'undefined') {
       envelope.payload = JSON.parse(envelope.payload);
     }
     return envelope;
@@ -65,7 +65,7 @@ class ChannelSuper extends EventEmitter {
   emitWrapper(type, msg) {
     const _this = this;
     setImmediate( () => {
-      if (msg) {
+      if (typeof msg !== 'undefined') {
         _this.emitLocal(type, msg);
       } else {
         _this.emitLocal(type);

--- a/install/nodejs-mobile-cordova-assets/builtin_modules/cordova-bridge/index.js
+++ b/install/nodejs-mobile-cordova-assets/builtin_modules/cordova-bridge/index.js
@@ -17,7 +17,7 @@ const EVENT_CHANNEL = '_EVENTS_';
 const SYSTEM_CHANNEL = '_SYSTEM_';
 
 /**
- * This classes is defined in www/nodejs-apis.js as well.
+ * This class is defined in www/nodejs-apis.js as well.
  * Any change made here should be ported to www/nodejs-apis.js too.
  * The MessageCodec class provides two static methods to serialize/deserialize
  * the data sent through the events channel.

--- a/install/nodejs-mobile-cordova-assets/builtin_modules/cordova-bridge/index.js
+++ b/install/nodejs-mobile-cordova-assets/builtin_modules/cordova-bridge/index.js
@@ -95,6 +95,34 @@ class EventChannel extends ChannelSuper {
 };
 
 /**
+ * System event Lock class
+ * Helper class to handle lock acquisition and release in system event handlers.
+ * Will call a callback after every lock has been released.
+ **/
+class SystemEventLock {
+  constructor(callback, startingLocks) {
+    this._locksAcquired = startingLocks; // Start with one lock.
+    this._callback = callback; // Callback to call after all locks are released.
+    this._hasReleased = false; // To stop doing anything after it's supposed to serve its purpose.
+    this._checkRelease(); // Initial check. If it's been started with no locks, can be released right away.
+  }
+  // Release a lock and call the callback if all locks have been released.
+  release() {
+    if (this._hasReleased) return;
+    this._locksAcquired--;
+    this._checkRelease();
+  }
+  // Check if the lock can be released and release it.
+  _checkRelease() {
+    if(this._locksAcquired<=0) {
+      this._hasReleased=true;
+      this._callback();
+    }
+  }
+
+}
+
+/**
  * System channel class.
  * Emit pause/resume events when the app goes to background/foreground.
  */
@@ -103,6 +131,34 @@ class SystemChannel extends ChannelSuper {
     super(name);
     // datadir should not change during runtime, so we cache it.
     this._cacheDataDir = null;
+  };
+
+  emitWrapper(type) {
+    // Overload the emitWrapper to handle the pause event locks.
+    const _this = this;
+    if (type.startsWith('pause')) {
+      setImmediate( () => {
+        let releaseMessage = 'release-pause-event';
+        let eventArguments = type.split('|');
+        if (eventArguments.length >= 2) {
+          // The expected format for the release message is "release-pause-event|{eventId}"
+          // eventId comes from the pause event, with the format "pause|{eventId}"
+          releaseMessage = releaseMessage + '|' + eventArguments[1];
+        }
+        // Create a lock to signal the native side after the app event has been handled.
+        let eventLock = new SystemEventLock(
+          () => {
+            NativeBridge.sendMessage(_this.name, releaseMessage);
+          }
+          , _this.listenerCount("pause") // A lock for each current event listener. All listeners need to call release().
+        );
+        _this.emitLocal("pause", eventLock);
+      });
+    } else {
+      setImmediate( () => {
+        _this.emitLocal(type);
+      });
+    }
   };
 
   processData(data) {
@@ -152,6 +208,9 @@ function registerChannel(channel) {
  */
 const systemChannel = new SystemChannel(SYSTEM_CHANNEL);
 registerChannel(systemChannel);
+
+// Signal we are ready for app events, so the native code won't lock before node is ready to handle those.
+NativeBridge.sendMessage(SYSTEM_CHANNEL, "ready-for-app-events");
 
 const eventChannel = new EventChannel(EVENT_CHANNEL);
 registerChannel(eventChannel);

--- a/install/nodejs-mobile-cordova-assets/builtin_modules/cordova-bridge/index.js
+++ b/install/nodejs-mobile-cordova-assets/builtin_modules/cordova-bridge/index.js
@@ -103,9 +103,23 @@ class EventChannel extends ChannelSuper {
  * Emit pause/resume events when the app goes to background/foreground.
  */
 class SystemChannel extends ChannelSuper {
+  constructor(name) {
+    super(name);
+    // datadir should not change during runtime, so we cache it.
+    this._cacheDataDir = null;
+  };
+
   processData(data) {
     // The data is the event.
     this.emitWrapper(data);
+  };
+
+  // Get a writable data directory for persistent file storage.
+  datadir() {
+    if (this._cacheDataDir===null) {
+      this._cacheDataDir=NativeBridge.getDataDir();
+    }
+    return this._cacheDataDir;
   };
 };
 

--- a/install/nodejs-mobile-cordova-assets/builtin_modules/cordova-bridge/package.json
+++ b/install/nodejs-mobile-cordova-assets/builtin_modules/cordova-bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-bridge",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Node.js for Mobile Apps Native Bridge",
   "main": "index.js",
   "scripts": {

--- a/install/sample-project/www/js/index.js
+++ b/install/sample-project/www/js/index.js
@@ -15,35 +15,78 @@ var app = {
 
   // Update DOM on a Received Event
   receivedEvent: function(id) {
-      var parentElement = document.getElementById(id);
-      var listeningElement = parentElement.querySelector('.listening');
-      var receivedElement = parentElement.querySelector('.received');
+    var parentElement = document.getElementById(id);
+    var listeningElement = parentElement.querySelector('.listening');
+    var receivedElement = parentElement.querySelector('.received');
 
-      listeningElement.setAttribute('style', 'display:none;');
-      receivedElement.setAttribute('style', 'display:block;');
+    listeningElement.setAttribute('style', 'display:none;');
+    receivedElement.setAttribute('style', 'display:block;');
 
-      console.log('Received Event: ' + id);
+    console.log('Received Event: ' + id);
   }
 };
-    
+
 app.initialize();
-    
+
+// In this example the channel listener handles only two types of messages:
+// - the 'Reply' object type that is defined in the www/nodejs-project/main.js
+// - the string type
+// But any other valid JavaScript type can be handled if desired.
 function channelListener(msg) {
-    console.log('[cordova] received: ' + msg);
+  if (typeof msg === 'string') {
+    console.log('[cordova] MESSAGE from Node: "' + msg + '"');
+  } else if (typeof msg === 'object') {
+    console.log('[cordova] MESSAGE from Node: "' + msg.reply + '" - In reply to: "' + msg.original + '"');
+  } else {
+    console.log('[cordova] unexpected object type: ' + typeof msg);
+  }
 };
 
-function startupCallback(err) {
-    if (err) {
-        console.log(err);
+// Events listener
+function startedEventistener(msg) {
+  if (msg) {
+    if (typeof msg === 'string') {
+      console.log('[cordova] "STARTED" event received from Node with a message: "' + msg + '"');
+    } else if (typeof msg === 'object') {
+      // Add your own logic there
     } else {
-        console.log ('Node.js Mobile Engine Started');
-        nodejs.channel.send('Hello from Cordova!');
+      console.log('[cordova] "unexpected object type: ' + typeof msg);
     }
+  } else {
+    console.log('[cordova] "STARTED" event received from Node');
+  }
 };
 
+// This is the callback passed to 'nodejs.start()' to be notified if the Node.js
+// engine has started successfully.
+function startupCallback(err) {
+  if (err) {
+    console.log(err);
+  } else {
+    console.log ('Node.js Mobile Engine started');
+    // Send a message to the Node.js app. The reply from the Node.js app will be
+    // processed by the message channel listener 'channelListener()`.
+    nodejs.channel.send('Hello from Cordova!');
+
+    // Send a sample event to the Node.js app.
+    nodejs.channel.post('myevent', 'An event from Cordova');
+  }
+};
+
+// The entry point to start the Node.js app.
 function startNodeProject() {
-    nodejs.channel.setListener(channelListener);
-    nodejs.start('main.js', startupCallback);
-    // To disable the stdout/stderr redirection to the Android logcat:
-    // nodejs.start('main.js', startupCallback, { redirectOutputToLogcat: false });
+  // Register the callbacks for the message channel and for the events channel
+  // before starting the Node.js engine.
+  nodejs.channel.setListener(channelListener);
+  nodejs.channel.on('started', startedEventistener);
+
+  // As an alternative to 'nodejs.channel.setListener', the 'nodejs.channel.on'
+  // method can be used:
+  // nodejs.channel.on('message', channelListener);
+
+  // Start the Node.js for Mobile Apps engine, passing the main script filename
+  // and a callback to receive the result of the startup process.
+  nodejs.start('main.js', startupCallback);
+  // To disable the stdout/stderr redirection to the Android logcat:
+  // nodejs.start('main.js', startupCallback, { redirectOutputToLogcat: false });
 };

--- a/install/sample-project/www/nodejs-project/main.js
+++ b/install/sample-project/www/nodejs-project/main.js
@@ -1,6 +1,45 @@
+// Require the 'cordova-bridge' to enable communications between the
+// Node.js app and the Cordova app.
 const cordova = require('cordova-bridge');
 
-cordova.channel.on('message', function (msg) { 
-  console.log('[node] received:', msg); 
-  cordova.channel.send('Replying to this message: ' + msg);
+// Send a message to Cordova.
+cordova.channel.send('main.js loaded');
+
+// Post an event to Cordova.
+cordova.channel.post('started');
+
+// Post an event with a message.
+cordova.channel.post('started', 'main.js loaded');
+
+// A sample object to show how the channel supports generic
+// JavaScript objects.
+class Reply {
+  constructor(replyMsg, originalMsg) {
+    this.reply = replyMsg;
+    this.original = originalMsg;
+  }
+};
+
+// Listen to messages from Cordova.
+cordova.channel.on('message', (msg) => {
+  console.log('[node] MESSAGE received: "%s"', msg);
+  // Reply sending a user defined object.
+  cordova.channel.send(new Reply('Message received!', msg));
+});
+
+// Listen to event 'myevent' from Cordova.
+cordova.channel.on('myevent', (msg) => {
+  console.log('[node] MYEVENT received with message: "%s"', msg);
+});
+
+// Handle the 'pause' and 'resume' events.
+// These are events raised automatically when the app switched to the
+// background/foreground.
+cordova.app.on('pause', () => {
+  console.log('[node] app paused.');
+});
+
+cordova.app.on('resume', () => {
+  console.log('[node] app resumed.');
+  cordova.channel.post('engine', 'resumed');
 });

--- a/plugin.xml
+++ b/plugin.xml
@@ -18,6 +18,10 @@
     <clobbers target="nodejs" />
   </js-module>
 
+  <js-module src="www/nodejs_events.js" name="nodejs_events">
+    <clobbers target="nodejs_events" />
+  </js-module>
+
   <!-- ios -->
   <platform name="ios">
 

--- a/src/android/java/com/janeasystems/cdvnodejsmobile/NodeJS.java
+++ b/src/android/java/com/janeasystems/cdvnodejsmobile/NodeJS.java
@@ -19,6 +19,8 @@ import android.content.res.AssetManager;
 import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
 import android.content.SharedPreferences;
+import android.system.Os;
+import android.system.ErrnoException;
 
 import java.io.*;
 import java.lang.System;
@@ -66,6 +68,7 @@ public class NodeJS extends CordovaPlugin {
 
   public native Integer startNodeWithArguments(String[] arguments, String nodePath, boolean redirectOutputToLogcat);
   public native void sendMessageToNodeChannel(String channelName, String msg);
+  public native void registerNodeDataDirPath(String dataDir);
   public native String getCurrentABIName();
 
   @Override
@@ -76,7 +79,17 @@ public class NodeJS extends CordovaPlugin {
     context = activity.getBaseContext();
     assetManager = activity.getBaseContext().getAssets();
 
+    // Sets the TMPDIR environment to the cacheDir, to be used in Node as os.tmpdir
+    try {
+      Os.setenv("TMPDIR", context.getCacheDir().getAbsolutePath(),true);
+    } catch (ErrnoException e) {
+      e.printStackTrace();
+    }
     filesDir = context.getFilesDir().getAbsolutePath();
+
+    // Register the filesDir as the Node data dir.
+    registerNodeDataDirPath(filesDir);
+
     nodeAppRootAbsolutePath = filesDir + "/" + PROJECT_ROOT;
     nodePath = nodeAppRootAbsolutePath + ":" + filesDir + "/" + BUILTIN_MODULES;
     trashDir = filesDir + "/" + TRASH_DIR;

--- a/src/android/jni/native-lib.cpp
+++ b/src/android/jni/native-lib.cpp
@@ -83,7 +83,7 @@ void rcv_message_from_node(const char* channel_name, const char* msg) {
   if (cls2 != nullptr) {
     // Find the method
     jmethodID m_sendMessage = env->GetStaticMethodID(cls2,
-                                                     "sendMessageToCordova",
+                                                     "sendMessageToApplication",
                                                      "(Ljava/lang/String;Ljava/lang/String;)V");
     if (m_sendMessage != nullptr) {
       jstring java_channel_name=env->NewStringUTF(channel_name);

--- a/src/android/jni/native-lib.cpp
+++ b/src/android/jni/native-lib.cpp
@@ -37,6 +37,17 @@ Java_com_janeasystems_cdvnodejsmobile_NodeJS_sendMessageToNodeChannel(
   env->ReleaseStringUTFChars(msg, nativeMessage);
 }
 
+extern "C"
+JNIEXPORT void JNICALL
+Java_com_janeasystems_cdvnodejsmobile_NodeJS_registerNodeDataDirPath(
+    JNIEnv *env,
+    jobject /* this */,
+    jstring dataDir) {
+  const char* nativeDataDir = env->GetStringUTFChars(dataDir, 0);
+  RegisterNodeDataDirPath(nativeDataDir);
+  env->ReleaseStringUTFChars(dataDir, nativeDataDir);
+}
+
 extern "C" int callintoNode(int argc, char *argv[]){
   const int exit_code = node::Start(argc,argv);
   return exit_code;

--- a/src/common/cordova-bridge/cordova-bridge.cpp
+++ b/src/common/cordova-bridge/cordova-bridge.cpp
@@ -15,7 +15,9 @@
 #include <cstring>
 #include <cstdlib>
 
-// Some helper macros from node/test/addons-napi/common.h
+/** 
+ * Some helper macros from node/test/addons-napi/common.h
+ */
 
 // Empty value so that macros here are able to return NULL or void
 #define NAPI_RETVAL_NOTHING  // Intentionally blank #define
@@ -72,154 +74,238 @@
 #define NAPI_CALL_RETURN_VOID(env, the_call)                             \
   NAPI_CALL_BASE(env, the_call, NAPI_RETVAL_NOTHING)
 
-class QueuedFunc {
-  public:
-    QueuedFunc(napi_env& env, napi_ref& function) : env(env), function(function) {
-    };
+/**
+ * Forward declarations
+ */
+void FlushMessageQueue(uv_async_t* handle);
+class Channel;
 
-    void notify_message(char *s) {
-      napi_env original_env = env;
-
-      napi_handle_scope scope;
-      napi_open_handle_scope(original_env, &scope);
-
-      napi_ref original_function_ref = function;
-
-      napi_value callback;
-      napi_get_reference_value(original_env, original_function_ref, &callback);
-      napi_value global;
-      napi_get_global(original_env, &global);
-
-      napi_value message;
-      napi_create_string_utf8(original_env, s, strlen(s), &message);
-
-      napi_value* argv = &message;
-      size_t argc = 1;
-
-      napi_value result;
-      napi_call_function(original_env, global, callback, argc, argv, &result);
-
-      napi_close_handle_scope(original_env, scope);
-    }
-
-  private:
-    napi_ref function;
-    napi_env env;
-};
-
-std::map<int32_t, QueuedFunc*> pool;
-int32_t my_little_pool_incrementer = 1;
+/**
+ * Global variables
+ */
+std::mutex channelsMutex;
+std::map<std::string, Channel*> channels;
 
 t_bridge_callback cordova_callback = NULL;
 
-std::mutex queueLock;
-std::queue<char*> messageQueue;
-uv_async_t* queue_uv_handle = NULL;
-
+/**
+ * Called by the Cordova plug-in to register the callback
+ * that receives the messages sent from Node.
+ */
 void RegisterBridgeCallback(t_bridge_callback callback) {
   cordova_callback = callback;
 }
 
-void close_cb(uv_handle_t* handle) {
-  free(((uv_async_t*)handle)->data);
-  free(handle);
+/**
+ * Channel class
+ */
+class Channel {
+  private:
+    napi_env env = NULL;
+    napi_ref function_ref = NULL;
+    uv_async_t* queue_uv_handle = NULL;
+    std::mutex uvhandleMutex;
+    std::mutex queueMutex;
+    std::queue<char*> messageQueue;
+    std::string name;
+    bool initialized = false;
+
+  public:
+    Channel(std::string name) : name(name) {};
+
+    // Set up the channel's NAPI data. This method can be called
+    // only once per channel.
+    void setNapiRefs(napi_env& env, napi_ref& function_ref) {
+      this->uvhandleMutex.lock();
+      if (this->queue_uv_handle == NULL) {
+        this->env = env;
+        this->function_ref = function_ref;
+
+        this->queue_uv_handle = (uv_async_t*)malloc(sizeof(uv_async_t));
+        uv_async_init(uv_default_loop(), this->queue_uv_handle, FlushMessageQueue);
+        this->queue_uv_handle->data = (void*)this;
+        initialized = true;
+        uv_async_send(this->queue_uv_handle);
+      } else {
+        napi_throw_error(env, NULL, "Channel already exists.");
+      }
+      this->uvhandleMutex.unlock();
+    };
+
+    // Add a new message to the channel's queue and notify libuv to
+    // call us back to do the actual message delivery.
+    void queueMessage(char* msg) {
+      this->queueMutex.lock();
+      this->messageQueue.push(msg);
+      this->queueMutex.unlock();
+
+      if (initialized) {
+        uv_async_send(this->queue_uv_handle);
+      }
+    };
+
+    // Process one message at the time, to simplify synchronization between
+    // threads and minimize lock retention.
+    void flushQueue() {
+      char* message = NULL;
+      bool empty = true;
+
+      this->queueMutex.lock();
+      if (!(this->messageQueue.empty())) {
+        message = this->messageQueue.front();
+        this->messageQueue.pop();
+        empty = this->messageQueue.empty();
+      }
+      this->queueMutex.unlock();
+
+      if (message != NULL) {
+        this->invokeNodeListener(message);
+        free(message);
+      }
+
+      if (!empty) {
+        uv_async_send(this->queue_uv_handle);   
+      }
+    };
+
+    // Calls into Node to execute the registered Node listener.
+    // This method is always executed on the main libuv loop thread.
+    void invokeNodeListener(char* msg) {
+      napi_handle_scope scope;
+      napi_open_handle_scope(this->env, &scope);
+
+      napi_value node_function;
+      napi_get_reference_value(this->env, this->function_ref, &node_function);
+      napi_value global;
+      napi_get_global(this->env, &global);
+      
+      napi_value channel_name;
+      napi_create_string_utf8(this->env, this->name.c_str(), this->name.size(), &channel_name);
+      
+      napi_value message;
+      napi_create_string_utf8(this->env, msg, strlen(msg), &message);
+
+      size_t argc = 2;
+      napi_value argv[argc];
+      argv[0] = channel_name;
+      argv[1] = message;
+
+      napi_value result;
+      napi_call_function(this->env, global, node_function, argc, argv, &result);
+      napi_close_handle_scope(this->env, scope);
+    };
 };
 
-void doRegisteredCallbacks(uv_async_t* handle) {
-  std::map<int32_t, QueuedFunc*> copiedPool;
-  copiedPool = pool;
-  char* message =(char*)(handle->data);
-  std::map<int32_t, QueuedFunc*>::iterator it;
-  for(it = copiedPool.begin(); it != copiedPool.end(); it++) {
-      it->second->notify_message(message);
+/**
+ * Return an existing channel or create a new one if it doesn't exist already.
+ */
+Channel* GetOrCreateChannel(std::string channelName) {
+  channelsMutex.lock();
+  Channel* channel = NULL;
+  auto it = channels.find(channelName);
+  if (it != channels.end()) {
+    channel = it->second;
+  } else {
+    channel = new Channel(channelName);
+    channels[channelName] = channel;
   }
-  uv_close((uv_handle_t*)handle, close_cb);
+  channelsMutex.unlock();
+  return channel;
+};
+
+/**
+ * Flush the specific channel queue 
+ */
+void FlushMessageQueue(uv_async_t* handle) {
+  Channel* channel = (Channel*)handle->data;
+  channel->flushQueue();
 }
 
-void flushMessageQueue(uv_async_t* handle) {
-    char* message;
-    queueLock.lock();
-    bool has_elements = !messageQueue.empty();
-    queueLock.unlock();
-    while (has_elements) {
-      queueLock.lock();
-      message = messageQueue.front();
-      messageQueue.pop();
-      has_elements = !messageQueue.empty();
-      queueLock.unlock();
-
-      uv_async_t* handle = (uv_async_t*)malloc(sizeof(uv_async_t));
-      uv_async_init(uv_default_loop(), handle, doRegisteredCallbacks);
-      handle->data = (void*)message;
-      uv_async_send(handle);
-    }
-}
-
-void init_queue_uv_handle() {
-  queue_uv_handle = (uv_async_t*)malloc(sizeof(uv_async_t));
-  uv_async_init(uv_default_loop(), queue_uv_handle, flushMessageQueue);
-  uv_async_send(queue_uv_handle);
-}
-
-napi_value Method_RegisterListener(napi_env env, napi_callback_info info) {
-  if (queue_uv_handle == NULL) {
-    init_queue_uv_handle();
-  }
-  size_t argc = 1;
-  napi_value args[1];
+/**
+ * Register a channel and its listener
+ */
+napi_value Method_RegisterChannel(napi_env env, napi_callback_info info) {
+  size_t argc = 2;
+  napi_value args[argc];
   NAPI_CALL(env, napi_get_cb_info(env, info, &argc, args, NULL, NULL));
-  NAPI_ASSERT(env, argc == 1, "Wrong number of arguments");
+  NAPI_ASSERT(env, argc == 2, "Wrong number of arguments.");
 
-  napi_value listener_function = args[0];
+  // args[0] is the channel name
+  napi_value channel_name = args[0];
   napi_valuetype valuetype0;
-  NAPI_CALL(env, napi_typeof(env, listener_function, &valuetype0));
-  NAPI_ASSERT(env, valuetype0 == napi_function, "Expected a function");
+  NAPI_CALL(env, napi_typeof(env, channel_name, &valuetype0));
+  NAPI_ASSERT(env, valuetype0 == napi_string, "Expected a string.");
 
+  size_t length;
+  size_t length_copied;
+  NAPI_CALL(env, napi_get_value_string_utf8(env, channel_name, NULL, 0, &length));
+
+  std::unique_ptr<char[]> unique_channelname_buf(new char[length + 1]());
+  char* channel_name_utf8 = unique_channelname_buf.get();
+  NAPI_CALL(env, napi_get_value_string_utf8(env, channel_name, channel_name_utf8, length + 1, &length_copied));
+  NAPI_ASSERT(env, length_copied == length, "Couldn't fully copy the channel name.");
+
+  // args[1] is the channel listener
+  napi_value listener_function = args[1];
+  napi_valuetype valuetype1;
+  NAPI_CALL(env, napi_typeof(env, listener_function, &valuetype1));
+  NAPI_ASSERT(env, valuetype1 == napi_function, "Expected a function.");
+  
   napi_ref ref_to_function;
   NAPI_CALL(env, napi_create_reference(env, listener_function, 1, &ref_to_function));
 
-  napi_value result;
-  NAPI_CALL(env, napi_create_int32(env, my_little_pool_incrementer, &result));
-
-  QueuedFunc *af = new QueuedFunc(env, ref_to_function);
-  pool[my_little_pool_incrementer++] = af;
-
-  return result;
+  Channel* channel = GetOrCreateChannel(channel_name_utf8);
+  channel->setNapiRefs(env, ref_to_function);
+  return nullptr;
 }
 
-// Let's make something appear on native code.
-napi_value Method_SendMessage(napi_env env, napi_callback_info info) {
-  size_t argc = 1;
-  napi_value args[1];
+/**
+ * Send a message to Cordova
+ */
+ napi_value Method_SendMessage(napi_env env, napi_callback_info info) {
+  size_t argc = 2;
+  napi_value args[argc];
 
   NAPI_CALL(env, napi_get_cb_info(env, info, &argc, args, NULL, NULL));
-  NAPI_ASSERT(env, argc == 1, "Wrong number of arguments");
+  NAPI_ASSERT(env, argc == 2, "Wrong number of arguments.");
 
-  napi_value value_to_log = args[0];
+  // TODO: arguments parsing and string conversion is done several times,
+  //       replace the duplicated code with a function or a macro.
 
+  // args[0] is the channel name
+  napi_value channel_name = args[0];
   napi_valuetype valuetype0;
-  NAPI_CALL(env, napi_typeof(env, value_to_log, &valuetype0));
-
-  if (valuetype0 != napi_string) {
-    NAPI_CALL(env, napi_coerce_to_string(env, value_to_log, &value_to_log));
-  }
+  NAPI_CALL(env, napi_typeof(env, channel_name, &valuetype0));
+  NAPI_ASSERT(env, valuetype0 == napi_string, "Expected a string.");
 
   size_t length;
-  size_t copied;
-  NAPI_CALL(env, napi_get_value_string_utf8(env, value_to_log, NULL, 0, &length));
+  size_t length_copied;
+  NAPI_CALL(env, napi_get_value_string_utf8(env, channel_name, NULL, 0, &length));
+  std::unique_ptr<char[]> unique_channelname_buf(new char[length + 1]());
+  char* channel_name_utf8 = unique_channelname_buf.get();
+  NAPI_CALL(env, napi_get_value_string_utf8(env, channel_name, channel_name_utf8, length + 1, &length_copied));
+  NAPI_ASSERT(env, length_copied == length, "Couldn't fully copy the channel name.");
 
-  // C++ cleans it automatically.
-  std::unique_ptr<char[]> unique_buffer(new char[length + 1]());
-  char *buff = unique_buffer.get();
+  // args[1] is the message string
+  napi_value message = args[1];
 
-  NAPI_CALL(env, napi_get_value_string_utf8(env, value_to_log, buff, length + 1, &copied));
-  NAPI_ASSERT(env, copied == length, "Couldn't fully copy the message");
-  NAPI_ASSERT(env, cordova_callback, "No callback is set in native code to receive the message");
-
-  if (cordova_callback) {
-    cordova_callback(buff);
+  napi_valuetype valuetype1;
+  NAPI_CALL(env, napi_typeof(env, message, &valuetype1));
+  if (valuetype1 != napi_string) {
+    NAPI_CALL(env, napi_coerce_to_string(env, message, &message));
   }
 
+  length = length_copied = 0;  
+  NAPI_CALL(env, napi_get_value_string_utf8(env, message, NULL, 0, &length));
+  std::unique_ptr<char[]> unique_msg_buf(new char[length + 1]());
+  char* msg_buf = unique_msg_buf.get();
+  NAPI_CALL(env, napi_get_value_string_utf8(env, message, msg_buf, length + 1, &length_copied));
+  NAPI_ASSERT(env, length_copied == length, "Couldn't fully copy the message.");
+
+  NAPI_ASSERT(env, cordova_callback, "No callback is set in native code to receive the message.");
+  if (cordova_callback) {
+    cordova_callback(channel_name_utf8, msg_buf);
+  }
   return nullptr;
 }
 
@@ -228,8 +314,8 @@ napi_value Method_SendMessage(napi_env env, napi_callback_info info) {
 napi_value Init(napi_env env, napi_value exports) {
   napi_status status;
   napi_property_descriptor properties[] = {
-      DECLARE_NAPI_METHOD("send", Method_SendMessage),
-      DECLARE_NAPI_METHOD("setListener", Method_RegisterListener),
+      DECLARE_NAPI_METHOD("sendMessage", Method_SendMessage),
+      DECLARE_NAPI_METHOD("registerChannel", Method_RegisterChannel),
   };
   NAPI_CALL(env, napi_define_properties(env, exports, sizeof(properties) / sizeof(*properties), properties));
   return exports;
@@ -238,19 +324,13 @@ napi_value Init(napi_env env, napi_value exports) {
 /**
  * This method is the public API called by the Cordova plugin
  */
-void SendToNode(const char *message) {
+void SendMessageToNodeChannel(const char* channelName, const char* message) {
   size_t messageLength = strlen(message);
   char* messageCopy = (char*)calloc(sizeof(char), messageLength + 1);
-
   strncpy(messageCopy, message, messageLength);
 
-  queueLock.lock();
-  messageQueue.push(messageCopy);
-  queueLock.unlock();
-
-  if (queue_uv_handle != NULL) {
-      uv_async_send(queue_uv_handle);
-  }
+  Channel* channel = GetOrCreateChannel(std::string(channelName));
+  channel->queueMessage(messageCopy);
 }
 
 // Register the native module at libnode startup

--- a/src/common/cordova-bridge/cordova-bridge.cpp
+++ b/src/common/cordova-bridge/cordova-bridge.cpp
@@ -96,6 +96,18 @@ void RegisterBridgeCallback(t_bridge_callback callback) {
   cordova_callback = callback;
 }
 
+char* datadir_path = NULL;
+/*
+ * Called by the Cordova plug-in to register the datadir,
+ * representing a writable path. Expected to be called once,
+ * while the plug-in initializes.
+ */
+void RegisterNodeDataDirPath(const char* path) {
+  size_t pathLength = strlen(path);
+  datadir_path = (char*)calloc(sizeof(char), pathLength + 1);
+  strncpy(datadir_path, path, pathLength);
+}
+
 /**
  * Channel class
  */
@@ -309,6 +321,17 @@ napi_value Method_RegisterChannel(napi_env env, napi_callback_info info) {
   return nullptr;
 }
 
+/**
+ * Get the registered datadir
+ */
+napi_value Method_GetDataDir(napi_env env, napi_callback_info info) {
+  NAPI_ASSERT(env, datadir_path!=NULL, "Data directory not set from native side.");
+  napi_value return_datadir;
+  size_t str_len = strlen(datadir_path);
+  NAPI_CALL(env, napi_create_string_utf8(env, datadir_path, str_len, &return_datadir));
+  return return_datadir;
+}
+
 #define DECLARE_NAPI_METHOD(name, func) { name, 0, func, 0, 0, 0, napi_default, 0 }
 
 napi_value Init(napi_env env, napi_value exports) {
@@ -316,6 +339,7 @@ napi_value Init(napi_env env, napi_value exports) {
   napi_property_descriptor properties[] = {
       DECLARE_NAPI_METHOD("sendMessage", Method_SendMessage),
       DECLARE_NAPI_METHOD("registerChannel", Method_RegisterChannel),
+      DECLARE_NAPI_METHOD("getDataDir", Method_GetDataDir),
   };
   NAPI_CALL(env, napi_define_properties(env, exports, sizeof(properties) / sizeof(*properties), properties));
   return exports;

--- a/src/common/cordova-bridge/cordova-bridge.h
+++ b/src/common/cordova-bridge/cordova-bridge.h
@@ -7,8 +7,8 @@
 #ifndef CORDOVA_BRIDGE_H_
 #define CORDOVA_BRIDGE_H_
 
-typedef void (*t_bridge_callback)(const char* arg);
+typedef void (*t_bridge_callback)(const char* channelName, const char* message);
 void RegisterBridgeCallback(t_bridge_callback);
-void SendToNode(const char *message);
+void SendMessageToNodeChannel(const char* channelName, const char* message);
 
 #endif

--- a/src/common/cordova-bridge/cordova-bridge.h
+++ b/src/common/cordova-bridge/cordova-bridge.h
@@ -10,5 +10,6 @@
 typedef void (*t_bridge_callback)(const char* channelName, const char* message);
 void RegisterBridgeCallback(t_bridge_callback);
 void SendMessageToNodeChannel(const char* channelName, const char* message);
+void RegisterNodeDataDirPath(const char* path);
 
 #endif

--- a/src/ios/CDVNodeJS.hh
+++ b/src/ios/CDVNodeJS.hh
@@ -9,11 +9,11 @@
 @interface CDVNodeJS : CDVPlugin
 {}
 
-@property NSString* messageListenerCallbackId;
+@property NSString* allChannelsListenerCallbackId;
 
 + (CDVNodeJS*) activeInstance;
 
-- (void) setChannelListener:(CDVInvokedUrlCommand*)command;
+- (void) setAllChannelsListener:(CDVInvokedUrlCommand*)command;
 
 - (void) sendMessageToNode:(CDVInvokedUrlCommand*)command;
 

--- a/src/ios/CDVNodeJS.mm
+++ b/src/ios/CDVNodeJS.mm
@@ -62,6 +62,10 @@ NSString* allChannelsListenerCallbackId = nil;
   
   RegisterBridgeCallback(sendMessageToCordova);
 
+  // Register the Documents Directory as the node dataDir.
+  NSString* nodeDataDir = [NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES) firstObject];
+  RegisterNodeDataDirPath([nodeDataDir UTF8String]);
+
   NSString* nodePath = [[NSProcessInfo processInfo] environment][NODE_PATH];
   NSString* appPath = [[NSBundle mainBundle] bundlePath];
   NSString* builtinModulesPath = [appPath stringByAppendingString:BUILTIN_MODULES];

--- a/www/nodejs_apis.js
+++ b/www/nodejs_apis.js
@@ -1,19 +1,116 @@
-// Bridge between the Cordova UI and the NodeJS plugin
+// Bridge between the Cordova UI and the Node.js Mobile plug-in
+
 'use strict';
 
-class Channel {};
+const EventEmitter = require('./nodejs_events');
 
-Channel.prototype.setListener = function (callback) {
-  cordova.exec(callback, callback, 'NodeJS', 'setChannelListener', null);
-};
+const EVENT_CHANNEL = '_EVENTS_';
 
-Channel.prototype.send = function (msg) {
-  cordova.exec(null, null, 'NodeJS', 'sendMessageToNode', [msg]);
+var channels = {};
+
+/*
+ * This classes is defined in cordova-bridge/index.js as well.
+ * Any change made here should be ported to cordova-bridge/index.js too.
+ * The MessageCodec class provides two static methods to serialize/deserialize
+ * the data sent through the events channel.
+*/
+class MessageCodec {
+  // This is a 'private' constructor, should only be used by this class
+  // static methods.
+  constructor(_event, _payload) {
+    this.event = _event;
+    this.payload = JSON.stringify(_payload);
+  };
+
+  // Serialize the message payload and the message.
+  static serialize(event, payload) {
+    const envelope = new MessageCodec(event, payload);
+    // Return the serialized message, that can be sent through a channel.
+    return JSON.stringify(envelope);
+  };
+
+  // Deserialize the message and the message payload.
+  static deserialize(message) {
+    var envelope = JSON.parse(message);
+    if (envelope.payload !== undefined) {
+      envelope.payload = JSON.parse(envelope.payload);
+    }
+    return envelope;
+  };
 };
 
 /**
- * Private methods
+ * Channel super class.
  */
+class ChannelSuper extends EventEmitter {
+  constructor(name) {
+    super();
+    this.name = name;
+    // Renaming the 'emit' method to 'emitLocal' is not strictly needed, but
+    // it is useful to clarify that 'emitting' on this object has a local
+    // scope: it emits the event on the Node side only, it doesn't send
+    // the event to Cordova.
+    this.emitLocal = this.emit;
+    delete this.emit;
+  };
+};
+
+/**
+ * Events channel class that supports user defined event types with
+ * an optional message. Allows to send any serializable
+ * JavaScript object supported by 'JSON.stringify()'.
+ * Sending functions is not currently supported.
+ * Includes the previously available 'send' method for 'message' events.
+ */
+class EventChannel extends ChannelSuper {
+  post(event, msg) {
+    cordova.exec(null, null, 'NodeJS', 'sendMessageToNode', [this.name, MessageCodec.serialize(event, msg)]);
+  };
+
+  // Posts a 'message' event, to be backward compatible with old code.
+  send(msg) {
+    this.post('message',msg);
+  };
+
+  // Sets a listener on the 'message' event, to be backward compatible with old code.
+  setListener(callback) {
+    this.on('message', callback);
+  };
+
+  processData(data) {
+    // The data contains the serialized message envelope.
+    var envelope = MessageCodec.deserialize(data);
+    this.emitLocal(envelope.event, envelope.payload);
+  };
+};
+
+/*
+ * Dispatcher for all channels. This method is called by the plug-in
+ * native code to deliver messages and events from Node.
+ * The first argument is the channel name.
+ * The second argument is the data.
+ */
+function allChannelsListener(args) {
+  const channelName = args[0];
+  const data = args[1];
+
+  if (channels.hasOwnProperty(channelName)) {
+    channels[channelName].processData(data);
+  } else {
+    console.error('Error: Channel not found:', channelName);
+  }
+};
+
+// Register the listern for all channels
+cordova.exec(allChannelsListener, allChannelsListener, 'NodeJS', 'setAllChannelsListener', null);
+
+/**
+ * Private methods.
+ */
+function registerChannel(channel) {
+  channels[channel.name] = channel;
+};
+
 function startEngine(command, args, callback) {
   cordova.exec(
     function(arg) {
@@ -33,7 +130,7 @@ function startEngine(command, args, callback) {
 };
 
 /**
- * Module exports
+ * Module exports.
  */
 function start(filename, callback, options) {
   options = options || {};
@@ -45,10 +142,11 @@ function startWithScript(script, callback, options) {
   startEngine('startEngineWithScript', [script, options], callback);
 };
 
-const channel = new Channel();
+const eventChannel = new EventChannel(EVENT_CHANNEL);
+registerChannel(eventChannel);
 
 module.exports = exports = {
   start,
   startWithScript,
-  channel
+  channel: eventChannel
 };

--- a/www/nodejs_apis.js
+++ b/www/nodejs_apis.js
@@ -32,7 +32,7 @@ class MessageCodec {
   // Deserialize the message and the message payload.
   static deserialize(message) {
     var envelope = JSON.parse(message);
-    if (envelope.payload !== undefined) {
+    if (typeof envelope.payload !== 'undefined') {
       envelope.payload = JSON.parse(envelope.payload);
     }
     return envelope;

--- a/www/nodejs_apis.js
+++ b/www/nodejs_apis.js
@@ -17,14 +17,14 @@ var channels = {};
 class MessageCodec {
   // This is a 'private' constructor, should only be used by this class
   // static methods.
-  constructor(_event, _payload) {
+  constructor(_event, ..._payload) {
     this.event = _event;
     this.payload = JSON.stringify(_payload);
   };
 
   // Serialize the message payload and the message.
-  static serialize(event, payload) {
-    const envelope = new MessageCodec(event, payload);
+  static serialize(event, ...payload) {
+    const envelope = new MessageCodec(event, ...payload);
     // Return the serialized message, that can be sent through a channel.
     return JSON.stringify(envelope);
   };
@@ -57,19 +57,19 @@ class ChannelSuper extends EventEmitter {
 
 /**
  * Events channel class that supports user defined event types with
- * an optional message. Allows to send any serializable
+ * optional arguments. Allows to send any serializable
  * JavaScript object supported by 'JSON.stringify()'.
  * Sending functions is not currently supported.
  * Includes the previously available 'send' method for 'message' events.
  */
 class EventChannel extends ChannelSuper {
-  post(event, msg) {
-    cordova.exec(null, null, 'NodeJS', 'sendMessageToNode', [this.name, MessageCodec.serialize(event, msg)]);
+  post(event, ...msg) {
+    cordova.exec(null, null, 'NodeJS', 'sendMessageToNode', [this.name, MessageCodec.serialize(event, ...msg)]);
   };
 
   // Posts a 'message' event, to be backward compatible with old code.
-  send(msg) {
-    this.post('message',msg);
+  send(...msg) {
+    this.post('message', ...msg);
   };
 
   // Sets a listener on the 'message' event, to be backward compatible with old code.
@@ -80,7 +80,7 @@ class EventChannel extends ChannelSuper {
   processData(data) {
     // The data contains the serialized message envelope.
     var envelope = MessageCodec.deserialize(data);
-    this.emitLocal(envelope.event, envelope.payload);
+    this.emitLocal(envelope.event, ...(envelope.payload));
   };
 };
 

--- a/www/nodejs_events.js
+++ b/www/nodejs_events.js
@@ -1,0 +1,527 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+'use strict';
+
+var domain;
+
+function EventEmitter() {
+  EventEmitter.init.call(this);
+}
+module.exports = EventEmitter;
+
+// Backwards-compat with node 0.10.x
+EventEmitter.EventEmitter = EventEmitter;
+
+EventEmitter.usingDomains = false;
+
+EventEmitter.prototype.domain = undefined;
+EventEmitter.prototype._events = undefined;
+EventEmitter.prototype._maxListeners = undefined;
+
+// By default EventEmitters will print a warning if more than 10 listeners are
+// added to it. This is a useful default which helps finding memory leaks.
+var defaultMaxListeners = 10;
+
+Object.defineProperty(EventEmitter, 'defaultMaxListeners', {
+  enumerable: true,
+  get: function() {
+    return defaultMaxListeners;
+  },
+  set: function(arg) {
+    // force global console to be compiled.
+    // see https://github.com/nodejs/node/issues/4467
+    console;
+    // check whether the input is a positive number (whose value is zero or
+    // greater and not a NaN).
+    if (typeof arg !== 'number' || arg < 0 || arg !== arg)
+      throw new TypeError('"defaultMaxListeners" must be a positive number');
+    defaultMaxListeners = arg;
+  }
+});
+
+EventEmitter.init = function() {
+  this.domain = null;
+  if (EventEmitter.usingDomains) {
+    // if there is an active domain, then attach to it.
+    domain = domain || require('domain');
+    if (domain.active && !(this instanceof domain.Domain)) {
+      this.domain = domain.active;
+    }
+  }
+
+  if (!this._events || this._events === Object.getPrototypeOf(this)._events) {
+    this._events = Object.create(null);
+    this._eventsCount = 0;
+  }
+
+  this._maxListeners = this._maxListeners || undefined;
+};
+
+// Obviously not all Emitters should be limited to 10. This function allows
+// that to be increased. Set to zero for unlimited.
+EventEmitter.prototype.setMaxListeners = function setMaxListeners(n) {
+  if (typeof n !== 'number' || n < 0 || isNaN(n))
+    throw new TypeError('"n" argument must be a positive number');
+  this._maxListeners = n;
+  return this;
+};
+
+function $getMaxListeners(that) {
+  if (that._maxListeners === undefined)
+    return EventEmitter.defaultMaxListeners;
+  return that._maxListeners;
+}
+
+EventEmitter.prototype.getMaxListeners = function getMaxListeners() {
+  return $getMaxListeners(this);
+};
+
+// These standalone emit* functions are used to optimize calling of event
+// handlers for fast cases because emit() itself often has a variable number of
+// arguments and can be deoptimized because of that. These functions always have
+// the same number of arguments and thus do not get deoptimized, so the code
+// inside them can execute faster.
+function emitNone(handler, isFn, self) {
+  if (isFn)
+    handler.call(self);
+  else {
+    var len = handler.length;
+    var listeners = arrayClone(handler, len);
+    for (var i = 0; i < len; ++i)
+      listeners[i].call(self);
+  }
+}
+function emitOne(handler, isFn, self, arg1) {
+  if (isFn)
+    handler.call(self, arg1);
+  else {
+    var len = handler.length;
+    var listeners = arrayClone(handler, len);
+    for (var i = 0; i < len; ++i)
+      listeners[i].call(self, arg1);
+  }
+}
+function emitTwo(handler, isFn, self, arg1, arg2) {
+  if (isFn)
+    handler.call(self, arg1, arg2);
+  else {
+    var len = handler.length;
+    var listeners = arrayClone(handler, len);
+    for (var i = 0; i < len; ++i)
+      listeners[i].call(self, arg1, arg2);
+  }
+}
+function emitThree(handler, isFn, self, arg1, arg2, arg3) {
+  if (isFn)
+    handler.call(self, arg1, arg2, arg3);
+  else {
+    var len = handler.length;
+    var listeners = arrayClone(handler, len);
+    for (var i = 0; i < len; ++i)
+      listeners[i].call(self, arg1, arg2, arg3);
+  }
+}
+
+function emitMany(handler, isFn, self, args) {
+  if (isFn)
+    handler.apply(self, args);
+  else {
+    var len = handler.length;
+    var listeners = arrayClone(handler, len);
+    for (var i = 0; i < len; ++i)
+      listeners[i].apply(self, args);
+  }
+}
+
+EventEmitter.prototype.emit = function emit(type) {
+  var er, handler, len, args, i, events, domain;
+  var needDomainExit = false;
+  var doError = (type === 'error');
+
+  events = this._events;
+  if (events)
+    doError = (doError && events.error == null);
+  else if (!doError)
+    return false;
+
+  domain = this.domain;
+
+  // If there is no 'error' event listener then throw.
+  if (doError) {
+    if (arguments.length > 1)
+      er = arguments[1];
+    if (domain) {
+      if (!er)
+        er = new Error('Unhandled "error" event');
+      if (typeof er === 'object' && er !== null) {
+        er.domainEmitter = this;
+        er.domain = domain;
+        er.domainThrown = false;
+      }
+      domain.emit('error', er);
+    } else if (er instanceof Error) {
+      throw er; // Unhandled 'error' event
+    } else {
+      // At least give some kind of context to the user
+      const err = new Error('Unhandled "error" event. (' + er + ')');
+      err.context = er;
+      throw err;
+    }
+    return false;
+  }
+
+  handler = events[type];
+
+  if (!handler)
+    return false;
+
+  if (domain && this !== process) {
+    domain.enter();
+    needDomainExit = true;
+  }
+
+  var isFn = typeof handler === 'function';
+  len = arguments.length;
+  switch (len) {
+    // fast cases
+    case 1:
+      emitNone(handler, isFn, this);
+      break;
+    case 2:
+      emitOne(handler, isFn, this, arguments[1]);
+      break;
+    case 3:
+      emitTwo(handler, isFn, this, arguments[1], arguments[2]);
+      break;
+    case 4:
+      emitThree(handler, isFn, this, arguments[1], arguments[2], arguments[3]);
+      break;
+    // slower
+    default:
+      args = new Array(len - 1);
+      for (i = 1; i < len; i++)
+        args[i - 1] = arguments[i];
+      emitMany(handler, isFn, this, args);
+  }
+
+  if (needDomainExit)
+    domain.exit();
+
+  return true;
+};
+
+function _addListener(target, type, listener, prepend) {
+  var m;
+  var events;
+  var existing;
+
+  if (typeof listener !== 'function')
+    throw new TypeError('"listener" argument must be a function');
+
+  events = target._events;
+  if (!events) {
+    events = target._events = Object.create(null);
+    target._eventsCount = 0;
+  } else {
+    // To avoid recursion in the case that type === "newListener"! Before
+    // adding it to the listeners, first emit "newListener".
+    if (events.newListener) {
+      target.emit('newListener', type,
+                  listener.listener ? listener.listener : listener);
+
+      // Re-assign `events` because a newListener handler could have caused the
+      // this._events to be assigned to a new object
+      events = target._events;
+    }
+    existing = events[type];
+  }
+
+  if (!existing) {
+    // Optimize the case of one listener. Don't need the extra array object.
+    existing = events[type] = listener;
+    ++target._eventsCount;
+  } else {
+    if (typeof existing === 'function') {
+      // Adding the second element, need to change to array.
+      existing = events[type] =
+        prepend ? [listener, existing] : [existing, listener];
+    } else {
+      // If we've already got an array, just append.
+      if (prepend) {
+        existing.unshift(listener);
+      } else {
+        existing.push(listener);
+      }
+    }
+
+    // Check for listener leak
+    if (!existing.warned) {
+      m = $getMaxListeners(target);
+      if (m && m > 0 && existing.length > m) {
+        existing.warned = true;
+        const w = new Error('Possible EventEmitter memory leak detected. ' +
+                            `${existing.length} ${String(type)} listeners ` +
+                            'added. Use emitter.setMaxListeners() to ' +
+                            'increase limit');
+        w.name = 'MaxListenersExceededWarning';
+        w.emitter = target;
+        w.type = type;
+        w.count = existing.length;
+        process.emitWarning(w);
+      }
+    }
+  }
+
+  return target;
+}
+
+EventEmitter.prototype.addListener = function addListener(type, listener) {
+  return _addListener(this, type, listener, false);
+};
+
+EventEmitter.prototype.on = EventEmitter.prototype.addListener;
+
+EventEmitter.prototype.prependListener =
+    function prependListener(type, listener) {
+      return _addListener(this, type, listener, true);
+    };
+
+function onceWrapper() {
+  if (!this.fired) {
+    this.target.removeListener(this.type, this.wrapFn);
+    this.fired = true;
+    switch (arguments.length) {
+      case 0:
+        return this.listener.call(this.target);
+      case 1:
+        return this.listener.call(this.target, arguments[0]);
+      case 2:
+        return this.listener.call(this.target, arguments[0], arguments[1]);
+      case 3:
+        return this.listener.call(this.target, arguments[0], arguments[1],
+                                  arguments[2]);
+      default:
+        const args = new Array(arguments.length);
+        for (var i = 0; i < args.length; ++i)
+          args[i] = arguments[i];
+        this.listener.apply(this.target, args);
+    }
+  }
+}
+
+function _onceWrap(target, type, listener) {
+  var state = { fired: false, wrapFn: undefined, target, type, listener };
+  var wrapped = onceWrapper.bind(state);
+  wrapped.listener = listener;
+  state.wrapFn = wrapped;
+  return wrapped;
+}
+
+EventEmitter.prototype.once = function once(type, listener) {
+  if (typeof listener !== 'function')
+    throw new TypeError('"listener" argument must be a function');
+  this.on(type, _onceWrap(this, type, listener));
+  return this;
+};
+
+EventEmitter.prototype.prependOnceListener =
+    function prependOnceListener(type, listener) {
+      if (typeof listener !== 'function')
+        throw new TypeError('"listener" argument must be a function');
+      this.prependListener(type, _onceWrap(this, type, listener));
+      return this;
+    };
+
+// Emits a 'removeListener' event if and only if the listener was removed.
+EventEmitter.prototype.removeListener =
+    function removeListener(type, listener) {
+      var list, events, position, i, originalListener;
+
+      if (typeof listener !== 'function')
+        throw new TypeError('"listener" argument must be a function');
+
+      events = this._events;
+      if (!events)
+        return this;
+
+      list = events[type];
+      if (!list)
+        return this;
+
+      if (list === listener || list.listener === listener) {
+        if (--this._eventsCount === 0)
+          this._events = Object.create(null);
+        else {
+          delete events[type];
+          if (events.removeListener)
+            this.emit('removeListener', type, list.listener || listener);
+        }
+      } else if (typeof list !== 'function') {
+        position = -1;
+
+        for (i = list.length - 1; i >= 0; i--) {
+          if (list[i] === listener || list[i].listener === listener) {
+            originalListener = list[i].listener;
+            position = i;
+            break;
+          }
+        }
+
+        if (position < 0)
+          return this;
+
+        if (position === 0)
+          list.shift();
+        else
+          spliceOne(list, position);
+
+        if (list.length === 1)
+          events[type] = list[0];
+
+        if (events.removeListener)
+          this.emit('removeListener', type, originalListener || listener);
+      }
+
+      return this;
+    };
+
+EventEmitter.prototype.removeAllListeners =
+    function removeAllListeners(type) {
+      var listeners, events, i;
+
+      events = this._events;
+      if (!events)
+        return this;
+
+      // not listening for removeListener, no need to emit
+      if (!events.removeListener) {
+        if (arguments.length === 0) {
+          this._events = Object.create(null);
+          this._eventsCount = 0;
+        } else if (events[type]) {
+          if (--this._eventsCount === 0)
+            this._events = Object.create(null);
+          else
+            delete events[type];
+        }
+        return this;
+      }
+
+      // emit removeListener for all listeners on all events
+      if (arguments.length === 0) {
+        var keys = Object.keys(events);
+        var key;
+        for (i = 0; i < keys.length; ++i) {
+          key = keys[i];
+          if (key === 'removeListener') continue;
+          this.removeAllListeners(key);
+        }
+        this.removeAllListeners('removeListener');
+        this._events = Object.create(null);
+        this._eventsCount = 0;
+        return this;
+      }
+
+      listeners = events[type];
+
+      if (typeof listeners === 'function') {
+        this.removeListener(type, listeners);
+      } else if (listeners) {
+        // LIFO order
+        for (i = listeners.length - 1; i >= 0; i--) {
+          this.removeListener(type, listeners[i]);
+        }
+      }
+
+      return this;
+    };
+
+EventEmitter.prototype.listeners = function listeners(type) {
+  var evlistener;
+  var ret;
+  var events = this._events;
+
+  if (!events)
+    ret = [];
+  else {
+    evlistener = events[type];
+    if (!evlistener)
+      ret = [];
+    else if (typeof evlistener === 'function')
+      ret = [evlistener.listener || evlistener];
+    else
+      ret = unwrapListeners(evlistener);
+  }
+
+  return ret;
+};
+
+EventEmitter.listenerCount = function(emitter, type) {
+  if (typeof emitter.listenerCount === 'function') {
+    return emitter.listenerCount(type);
+  } else {
+    return listenerCount.call(emitter, type);
+  }
+};
+
+EventEmitter.prototype.listenerCount = listenerCount;
+function listenerCount(type) {
+  const events = this._events;
+
+  if (events) {
+    const evlistener = events[type];
+
+    if (typeof evlistener === 'function') {
+      return 1;
+    } else if (evlistener) {
+      return evlistener.length;
+    }
+  }
+
+  return 0;
+}
+
+EventEmitter.prototype.eventNames = function eventNames() {
+  return this._eventsCount > 0 ? Reflect.ownKeys(this._events) : [];
+};
+
+// About 1.5x faster than the two-arg version of Array#splice().
+function spliceOne(list, index) {
+  for (var i = index, k = i + 1, n = list.length; k < n; i += 1, k += 1)
+    list[i] = list[k];
+  list.pop();
+}
+
+function arrayClone(arr, n) {
+  var copy = new Array(n);
+  for (var i = 0; i < n; ++i)
+    copy[i] = arr[i];
+  return copy;
+}
+
+function unwrapListeners(arr) {
+  const ret = new Array(arr.length);
+  for (var i = 0; i < ret.length; ++i) {
+    ret[i] = arr[i].listener || arr[i];
+  }
+  return ret;
+}


### PR DESCRIPTION
This PR adds to the plugin's APIs:
 - JSON serializable messages can now be sent through the plugin, and many arguments can be sent.
 - different event names can now be sent through the channel.
 - the cordova side API is now more similar to the node side events API.
 - `os.tmpdir()` will now return the application's cache directory on Android.
 - an app channel was added to handle pause / resume events in the node side and to get a writable path.