### PR TITLE
fix ios build failed issue

### DIFF
--- a/install/hooks/ios/after-plugin-install.js
+++ b/install/hooks/ios/after-plugin-install.js
@@ -122,6 +122,7 @@ node "$PATCH_SCRIPT_DIR"/ios-create-plists-and-dlopen-override.js $NODEJS_PROJEC
 embed_framework()
 {
     FRAMEWORK_NAME="$(basename "$1")"
+    mkdir -p "$TARGET_BUILD_DIR/$FRAMEWORKS_FOLDER_PATH/"
     cp -r "$1" "$TARGET_BUILD_DIR/$FRAMEWORKS_FOLDER_PATH/"
     /usr/bin/codesign --force --sign $EXPANDED_CODE_SIGN_IDENTITY --preserve-metadata=identifier,entitlements,flags --timestamp=none "$TARGET_BUILD_DIR/$FRAMEWORKS_FOLDER_PATH/$FRAMEWORK_NAME"
 }


### PR DESCRIPTION
cp -r behavior is different when the target path exists or not. It will cause the sign step failed.
cp -r ~/files ~/files-backup
If the directory files-backup already exists, the directory files will be placed inside.
If files-backup does not already exist, it will be created and the contents of the files directory will be placed inside it.