### PR TITLE
Fix to support Cordova 9. 

### DIFF
--- a/install/hooks/android/after-prepare-build-node-assets-lists.js
+++ b/install/hooks/android/after-prepare-build-node-assets-lists.js
@@ -26,7 +26,7 @@ function enumFolder(folderPath) {
 
 function createFileAndFolderLists(context, callback) {
   try {
-    var cordovaLib = context.requireCordovaModule('cordova-lib');
+    var cordovaLib = require('cordova-lib');
     var platformAPI = cordovaLib.cordova_platforms.getPlatformApi('android');
     var nodeJsProjectRoot = 'www/nodejs-project';
     // The Android application's assets path will be the parent of the application's www folder.
@@ -50,16 +50,13 @@ module.exports = function(context) {
     return;
   }
 
-  var Q = context.requireCordovaModule('q');
-  var deferral = new Q.defer();
-
-  createFileAndFolderLists(context, function(err) {
-    if (err) {
-      deferral.reject(err);
-    } else {
-      deferral.resolve();
-    }
+  return new Promise((resolve, reject) => {
+    createFileAndFolderLists(context, function(err) {
+      if (err) {
+        reject(err);
+      } else {
+        resolve();
+      }
+    });
   });
-
-  return deferral.promise;
 }

--- a/install/hooks/android/before-plugin-install.js
+++ b/install/hooks/android/before-plugin-install.js
@@ -38,22 +38,19 @@ function unzipAll(callback) {
 }
 
 module.exports = function(context) {
-  var Q = context.requireCordovaModule('q');
-  var deferral = new Q.defer();
-
   // Create the node project folder if it doesn't exist
   if (!fs.existsSync(nodeProjectFolder)) {
     fs.mkdirSync(nodeProjectFolder);
   }
 
-  // Unzip the libnode.so files for each architecture
-  unzipAll(function(err) {
-    if (err) {
-      deferral.reject(err);
-    } else {
-      deferral.resolve();
-    }
+  return new Promise((resolve, reject) => {
+    // Unzip the libnode.so files for each architecture
+    unzipAll(function(err) {
+        if (err) {
+        reject(err);
+        } else {
+        resolve();
+        }
+    });
   });
-
-  return deferral.promise;
 }

--- a/install/hooks/ios/after-plugin-install.js
+++ b/install/hooks/ios/after-plugin-install.js
@@ -2,7 +2,7 @@ var path = require('path');
 var fs = require('fs');
 
 module.exports = function(context) {
-  var xcode = context.requireCordovaModule('xcode');
+  var xcode = require('xcode');
 
   // Require the iOS platform Api to get the Xcode .pbxproj path.
   var iosPlatformPath = path.join(context.opts.projectRoot, 'platforms', 'ios');

--- a/install/hooks/ios/before-plugin-install.js
+++ b/install/hooks/ios/before-plugin-install.js
@@ -9,29 +9,26 @@ const zipFileName = nodeMobileFileName + '.tar.zip';
 const zipFilePath = nodeMobileFolderPath + zipFileName
 
 module.exports = function(context) {
-  var Q = context.requireCordovaModule('q');
-  var deferral = new Q.defer();
-  
   // Create the node project folder if it doesn't exist
   if (!fs.existsSync(nodeProjectFolder)) {
     fs.mkdirSync(nodeProjectFolder);
   }
 
-  // Unzip and untar the libnode.Framework
-  if (fs.existsSync(zipFilePath)) {  
-    targz2().extract(zipFilePath, nodeMobileFolderPath, function(err) {
-      if (err) {
-        deferral.reject(err);
-      } else {
-        fs.unlinkSync(zipFilePath);
-        deferral.resolve();
-      }
-    });
-  } else if (!fs.existsSync(nodeMobileFilePath)) {
-    deferral.reject(new Error(nodeMobileFileName + ' is missing'));
-  } else {
-    deferral.resolve();
-  }
-  
-  return deferral.promise;
+  return new Promise((resolve, reject) => {
+      // Unzip and untar the libnode.Framework
+    if (fs.existsSync(zipFilePath)) {
+        targz2().extract(zipFilePath, nodeMobileFolderPath, function(err) {
+        if (err) {
+            reject(err);
+        } else {
+            fs.unlinkSync(zipFilePath);
+            resolve();
+        }
+        });
+    } else if (!fs.existsSync(nodeMobileFilePath)) {
+        reject(new Error(nodeMobileFileName + ' is missing'));
+    } else {
+        resolve();
+    }
+  });
 }

--- a/install/hooks/ios/before-plugin-uninstall.js
+++ b/install/hooks/ios/before-plugin-uninstall.js
@@ -2,7 +2,7 @@ var path = require('path');
 var fs = require('fs');
 
 module.exports = function(context) {
-  var xcode = context.requireCordovaModule('xcode');
+  var xcode = require('xcode');
 
   // Adds a custom function to remove script build phases, which is not supported on cordova's Xcode module yet.
   xcode.project.prototype.myRemovePbxScriptBuildPhase = function (buildPhaseName, target) {

--- a/tests/hooks/both/install-nodejs-test-project.js
+++ b/tests/hooks/both/install-nodejs-test-project.js
@@ -3,15 +3,12 @@ const path = require('path');
 
 module.exports = function(context)
 {
-  var Q = context.requireCordovaModule('q');
-  var deferral = new Q.defer();
-
   var projectRoot = context.opts.projectRoot;
   var pluginRoot = context.opts.plugin.dir;
 
-  fse.copy(path.join(pluginRoot,'nodejs-project'),path.join(projectRoot,'www','nodejs-project'))
-  .then( () => deferral.resolve() )
-  .catch ( err => deferral.reject(err) );
-
-  return deferral.promise;
+  return new Promise((resolve, reject) => {
+    fse.copy(path.join(pluginRoot,'nodejs-project'),path.join(projectRoot,'www','nodejs-project'))
+    .then( () => resolve() )
+    .catch ( err => reject(err) );
+  });
 }


### PR DESCRIPTION
The use of context.requireCordovaModule for non-cordova dependencies has been removed use 'require' instead. Cordova Dropped the use of 'Q' Dependency use Native Promises instead.