### PR TITLE
Fix to support Cordova 10

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ## Installation
 
 ```bash
-$ cordova plugin add @red-mobile/nodejs-mobile-cordova
+$ cordova plugin add nodejs-mobile-cordova
 ```
 
 ## Requirements

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ## Installation
 
 ```bash
-$ cordova plugin add nodejs-mobile-cordova
+$ cordova plugin add @red-mobile/nodejs-mobile-cordova
 ```
 
 ## Requirements

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
-  "name": "@red-mobile/nodejs-mobile-cordova",
+  "name": "nodejs-mobile-cordova",
   "version": "0.4.3",
   "description": "Node.js for Mobile Apps Cordova plugin",
   "cordova": {
-    "id": "@red-mobile/nodejs-mobile-cordova",
+    "id": "nodejs-mobile-cordova",
     "platforms": [
       "ios",
       "android"

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
-  "name": "nodejs-mobile-cordova",
-  "version": "0.4.2",
+  "name": "@red-mobile/nodejs-mobile-cordova",
+  "version": "0.4.3",
   "description": "Node.js for Mobile Apps Cordova plugin",
   "cordova": {
-    "id": "nodejs-mobile-cordova",
+    "id": "@red-mobile/nodejs-mobile-cordova",
     "platforms": [
       "ios",
       "android"
@@ -26,13 +26,13 @@
     "tar.gz2": "^1.0.0",
     "xcode": "^2.0.0"
   },
-  "homepage": "https://code.janeasystems.com/nodejs-mobile",
+  "homepage": "https://github.com/okhiroyuki/nodejs-mobile-cordova",
   "repository": {
     "type": "git",
-    "url": "https://github.com/janeasystems/nodejs-mobile-cordova"
+    "url": "https://github.com/okhiroyuki/nodejs-mobile-cordova"
   },
   "bugs": {
-    "url": "https://github.com/janeasystems/nodejs-mobile/issues"
+    "url": "https://github.com/okhiroyuki/nodejs-mobile/issues"
   },
   "engines": {
     "cordovaDependencies": {

--- a/plugin.xml
+++ b/plugin.xml
@@ -74,6 +74,10 @@
       <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
     </config-file>
 
+    <config-file target="res/xml/config.xml" parent="/*">
+      <preference name="android-minSdkVersion" value="21" />
+    </config-file>
+
     <source-file src="src/android/java/com/janeasystems/cdvnodejsmobile/NodeJS.java" target-dir="src/com/janeasystems/cdvnodejsmobile/" />
 
     <source-file src="src/common/cordova-bridge/cordova-bridge.h" target-dir="libs/cdvnodejsmobile/" />

--- a/plugin.xml
+++ b/plugin.xml
@@ -90,7 +90,7 @@
 
     <framework src="src/android/build.gradle" custom="true" type="gradleReference" />
     <framework src="org.zeroturnaround:zt-zip:1.14" />
-    <framework src="commons-io:commons-io:jar:2.8.0" />
+    <framework src="commons-io:commons-io:jar:2.6.0" />
     <source-file src="src/android/CMakeLists.txt" target-dir="libs/cdvnodejsmobile/"/>
 
   </platform>

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
-           id="nodejs-mobile-cordova"
-      version="0.4.2">
+           id="@red-mobile/nodejs-mobile-cordova"
+      version="0.4.3">
 
   <name>Node.js Mobile</name>
   <description>Node.js for Mobile Apps Cordova Plugin</description>

--- a/plugin.xml
+++ b/plugin.xml
@@ -89,6 +89,8 @@
     <source-file src="install/nodejs-mobile-cordova-assets/" target-dir="assets/" />
 
     <framework src="src/android/build.gradle" custom="true" type="gradleReference" />
+    <framework src="org.zeroturnaround:zt-zip:1.14" />
+    <framework src="commons-io:commons-io:jar:2.8.0" />
     <source-file src="src/android/CMakeLists.txt" target-dir="libs/cdvnodejsmobile/"/>
 
   </platform>

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
-           id="@red-mobile/nodejs-mobile-cordova"
+           id="nodejs-mobile-cordova"
       version="0.4.3">
 
   <name>Node.js Mobile</name>

--- a/plugin.xml
+++ b/plugin.xml
@@ -74,10 +74,6 @@
       <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
     </config-file>
 
-    <edit-config file="AndroidManifest.xml" target="/manifest/uses-sdk" mode="merge">
-      <uses-sdk android:minSdkVersion="21" />
-    </edit-config>
-
     <source-file src="src/android/java/com/janeasystems/cdvnodejsmobile/NodeJS.java" target-dir="src/com/janeasystems/cdvnodejsmobile/" />
 
     <source-file src="src/common/cordova-bridge/cordova-bridge.h" target-dir="src/com/janeasystems/cdvnodejsmobile/jni/" />

--- a/plugin.xml
+++ b/plugin.xml
@@ -90,7 +90,7 @@
 
     <framework src="src/android/build.gradle" custom="true" type="gradleReference" />
     <framework src="org.zeroturnaround:zt-zip:1.14" />
-    <framework src="commons-io:commons-io:jar:2.6.0" />
+    <framework src="commons-io:commons-io:2.8.0" />
     <source-file src="src/android/CMakeLists.txt" target-dir="libs/cdvnodejsmobile/"/>
 
   </platform>

--- a/src/android/build.gradle
+++ b/src/android/build.gradle
@@ -42,8 +42,6 @@ cdvPluginPostBuildExtras += { ->
     // The file that caches the value of NODEJS_MOBILE_BUILD_NATIVE_MODULES is not needed inside the APK.
     android.aaptOptions.ignoreAssetsPattern += ":!NODEJS_MOBILE_BUILD_NATIVE_MODULES_VALUE.txt";
 
-    android.sourceSets.main.jniLibs.srcDirs += 'libs/cdvnodejsmobile/libnode/bin/';
-
     String projectWWW; // www assets folder from the Application project.
     if ( file("${project.projectDir}/src/main/assets/www/").exists() ) {
         // www folder for cordova-android >= 7

--- a/src/android/build.gradle
+++ b/src/android/build.gradle
@@ -27,6 +27,7 @@ android {
 }
 
 import org.gradle.internal.os.OperatingSystem;
+import org.gradle.util.GradleVersion;
 
 cdvPluginPostBuildExtras += { ->
     if (android.defaultConfig.ndk.abiFilters == null) {
@@ -41,6 +42,10 @@ cdvPluginPostBuildExtras += { ->
     android.aaptOptions.ignoreAssetsPattern += ":!build-native-modules-MacOS-helper-script.sh";
     // The file that caches the value of NODEJS_MOBILE_BUILD_NATIVE_MODULES is not needed inside the APK.
     android.aaptOptions.ignoreAssetsPattern += ":!NODEJS_MOBILE_BUILD_NATIVE_MODULES_VALUE.txt";
+
+    if (GradleVersion.current() < GradleVersion.version("4.0")) {
+        android.sourceSets.main.jniLibs.srcDirs += 'libs/cdvnodejsmobile/libnode/bin/';
+    }
 
     String projectWWW; // www assets folder from the Application project.
     if ( file("${project.projectDir}/src/main/assets/www/").exists() ) {

--- a/src/android/java/com/janeasystems/cdvnodejsmobile/NodeJS.java
+++ b/src/android/java/com/janeasystems/cdvnodejsmobile/NodeJS.java
@@ -27,6 +27,9 @@ import java.lang.System;
 import java.util.*;
 import java.util.concurrent.Semaphore;
 
+import org.zeroturnaround.zip.ZipUtil;
+import org.zeroturnaround.zip.commons.FileUtils;
+
 public class NodeJS extends CordovaPlugin {
 
   private static Activity activity = null;
@@ -452,12 +455,28 @@ public class NodeJS extends CordovaPlugin {
       Log.d(LOGTAG, "Copying node project assets enumerating the APK assets folder");
       copyFolder(PROJECT_ROOT);
     }
+    
+    // Copy Custom Node Modules
+    copyCustomNodeModules();
 
     // Copy native modules assets
     copyNativeAssets();
 
     Log.d(LOGTAG, "Node assets copied");
     saveLastUpdateTime();
+  }
+
+  private copyCustomNodeModules(){
+    File srcDir = new File(filesDir, "node_modules.zip");
+    if(srcDir.exists()){
+        try {
+            File nodejsModulesFolder = new File(NodeJS.filesDir + "/" + PROJECT_ROOT_MODULES);
+            FileUtils.deleteDirectory(nodejsModulesFolder);
+            ZipUtil.unpack(srcDir, nodejsModulesFolder);
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
   }
 
   private ArrayList<String> readFileFromAssets(String filename){

--- a/src/android/java/com/janeasystems/cdvnodejsmobile/NodeJS.java
+++ b/src/android/java/com/janeasystems/cdvnodejsmobile/NodeJS.java
@@ -466,12 +466,15 @@ public class NodeJS extends CordovaPlugin {
     saveLastUpdateTime();
   }
 
-  private copyCustomNodeModules(){
+  private void copyCustomNodeModules(){
     File srcDir = new File(filesDir, "node_modules.zip");
     if(srcDir.exists()){
+        Log.d(LOGTAG, "Custom Node Modules exists.");
         try {
             File nodejsModulesFolder = new File(NodeJS.filesDir + "/" + PROJECT_ROOT_MODULES);
+            Log.d(LOGTAG, "Delete current nodejsModules Folder.");
             FileUtils.deleteDirectory(nodejsModulesFolder);
+            Log.d(LOGTAG, "Custom Node Modules unpack.");
             ZipUtil.unpack(srcDir, nodejsModulesFolder);
         } catch (IOException e) {
             e.printStackTrace();

--- a/src/android/java/com/janeasystems/cdvnodejsmobile/NodeJS.java
+++ b/src/android/java/com/janeasystems/cdvnodejsmobile/NodeJS.java
@@ -361,7 +361,7 @@ public class NodeJS extends CordovaPlugin {
 
   private boolean isEmptyNodeModules(){
     File nodejsModulesFolder = new File(NodeJS.filesDir + "/" + PROJECT_ROOT_MODULES);
-    return nodejsModulesFolder.exists();
+    return !nodejsModulesFolder.exists();
   }
 
   private boolean wasAPKUpdated() {

--- a/src/android/java/com/janeasystems/cdvnodejsmobile/NodeJS.java
+++ b/src/android/java/com/janeasystems/cdvnodejsmobile/NodeJS.java
@@ -35,6 +35,7 @@ public class NodeJS extends CordovaPlugin {
 
   private static String filesDir;
   private static final String PROJECT_ROOT = "www/nodejs-project";
+  private static final String PROJECT_ROOT_MODULES = "www/nodejs-project/node_modules";
   private static final String BUILTIN_ASSETS = "nodejs-mobile-cordova-assets";
   private static final String BUILTIN_MODULES = "nodejs-mobile-cordova-assets/builtin_modules";
   private static final String TRASH_DIR = "nodejs-project-trash";
@@ -103,7 +104,7 @@ public class NodeJS extends CordovaPlugin {
   }
 
   private void asyncInit() {
-    if (wasAPKUpdated()) {
+    if (wasAPKUpdated() || isEmptyNodeModules()) {
       try {
         initSemaphore.acquire();
         new Thread(new Runnable() {
@@ -356,6 +357,11 @@ public class NodeJS extends CordovaPlugin {
         ie.printStackTrace();
       }
     }
+  }
+
+  private boolean isEmptyNodeModules(){
+    File nodejsModulesFolder = new File(NodeJS.filesDir + "/" + PROJECT_ROOT_MODULES);
+    return nodejsModulesFolder.exists();
   }
 
   private boolean wasAPKUpdated() {


### PR DESCRIPTION
To support Cordova 10, the following two fixes have been made.

- Fix how to specify the minSdkVersion
- Handling of jniLibs in Gradle 4

## Fix how to specify the minSdkVersion
modified how to specify minSdkVersion in /manifest/uses-sdk because of an error.

### error message
```
Installing "nodejs-mobile-cordova" for android
Failed to install 'nodejs-mobile-cordova': Error: Unable to graft xml at selector "/manifest/uses-sdk" from "/Users/okhiroyuki/Documents/github/RedMobile/platforms/android/app/src/main/AndroidManifest.xml" during config install
    at ConfigFile.graft_child (/Users/okhiroyuki/Documents/github/RedMobile/node_modules/cordova-common/src/ConfigChanges/ConfigFile.js:117:23)
    at PlatformMunger.apply_file_munge (/Users/okhiroyuki/Documents/github/RedMobile/node_modules/cordova-common/src/ConfigChanges/ConfigChanges.js:76:43)
    at PlatformMunger._munge_helper (/Users/okhiroyuki/Documents/github/RedMobile/node_modules/cordova-common/src/ConfigChanges/ConfigChanges.js:219:18)
    at PlatformMunger.add_plugin_changes (/Users/okhiroyuki/Documents/github/RedMobile/node_modules/cordova-common/src/ConfigChanges/ConfigChanges.js:148:14)
    at /Users/okhiroyuki/Documents/github/RedMobile/node_modules/cordova-common/src/PluginManager.js:121:33
    at _fulfilled (/Users/okhiroyuki/Documents/github/RedMobile/node_modules/q/q.js:854:54)
    at /Users/okhiroyuki/Documents/github/RedMobile/node_modules/q/q.js:883:30
    at Promise.promise.promiseDispatch (/Users/okhiroyuki/Documents/github/RedMobile/node_modules/q/q.js:816:13)
    at /Users/okhiroyuki/Documents/github/RedMobile/node_modules/q/q.js:877:14
    at runSingle (/Users/okhiroyuki/Documents/github/RedMobile/node_modules/q/q.js:137:13)
Unable to graft xml at selector "/manifest/uses-sdk" from "/Users/okhiroyuki/Documents/github/RedMobile/platforms/android/app/src/main/AndroidManifest.xml" during config install
```

## Handling of jniLibs in Gradle 4

Since Gradle 4.0, jniLibs has been removed as it is no longer needed.

refs: https://developer.android.com/studio/releases/gradle-plugin#cmake-imported-targets

Fix to check GradleVersion instead of simply deleting it.

### error message

```
> Task :app:mergeDebugNativeLibs FAILED

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':app:mergeDebugNativeLibs'.
> A failure occurred while executing com.android.build.gradle.internal.tasks.Workers$ActionFacade
   > More than one file was found with OS independent path 'lib/arm64-v8a/libnode.so'. If you are using jniLibs and CMake IMPORTED targets, see https://developer.android.com/studio/preview/features#automatic_packaging_of_prebuilt_dependencies_used_by_cmake

* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output. Run with --scan to get full insights.

* Get more help at https://help.gradle.org

Deprecated Gradle features were used in this build, making it incompatible with Gradle 7.0.
Use '--warning-mode all' to show the individual deprecation warnings.
See https://docs.gradle.org/6.5/userguide/command_line_interface.html#sec:command_line_warnings

BUILD FAILED in 20s
41 actionable tasks: 8 executed, 33 up-to-date
```