### PR TITLE
Fix to support Cordova 10

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@ $ cordova plugin add nodejs-mobile-cordova
 
 ## Requirements
 
- - Cordova 7.x or higher
+ - Cordova 9.x or higher
  - iOS 11 or higher
- - Android API 21 or higher
+ - Android API 22 or higher
 
 When building an application for the Android platform, make sure you have the [Android NDK](https://developer.android.com/ndk/index.html) installed and the environment variable `ANDROID_NDK_HOME` set, for example:
 ```bash

--- a/plugin.xml
+++ b/plugin.xml
@@ -74,10 +74,6 @@
       <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
     </config-file>
 
-    <config-file target="res/xml/config.xml" parent="/*">
-      <preference name="android-minSdkVersion" value="21" />
-    </config-file>
-
     <source-file src="src/android/java/com/janeasystems/cdvnodejsmobile/NodeJS.java" target-dir="src/com/janeasystems/cdvnodejsmobile/" />
 
     <source-file src="src/common/cordova-bridge/cordova-bridge.h" target-dir="libs/cdvnodejsmobile/" />

--- a/plugin.xml
+++ b/plugin.xml
@@ -74,6 +74,10 @@
       <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
     </config-file>
 
+    <config-file target="res/xml/config.xml" parent="/*">
+      <preference name="android-minSdkVersion" value="21" />
+    </config-file>
+
     <source-file src="src/android/java/com/janeasystems/cdvnodejsmobile/NodeJS.java" target-dir="src/com/janeasystems/cdvnodejsmobile/" />
 
     <source-file src="src/common/cordova-bridge/cordova-bridge.h" target-dir="libs/cdvnodejsmobile/" />

--- a/plugin.xml
+++ b/plugin.xml
@@ -74,10 +74,6 @@
       <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
     </config-file>
 
-    <edit-config file="AndroidManifest.xml" target="/manifest/uses-sdk" mode="merge">
-      <uses-sdk android:minSdkVersion="21" />
-    </edit-config>
-
     <source-file src="src/android/java/com/janeasystems/cdvnodejsmobile/NodeJS.java" target-dir="src/com/janeasystems/cdvnodejsmobile/" />
 
     <source-file src="src/common/cordova-bridge/cordova-bridge.h" target-dir="src/com/janeasystems/cdvnodejsmobile/jni/" />

--- a/src/android/build.gradle
+++ b/src/android/build.gradle
@@ -42,8 +42,6 @@ cdvPluginPostBuildExtras += { ->
     // The file that caches the value of NODEJS_MOBILE_BUILD_NATIVE_MODULES is not needed inside the APK.
     android.aaptOptions.ignoreAssetsPattern += ":!NODEJS_MOBILE_BUILD_NATIVE_MODULES_VALUE.txt";
 
-    android.sourceSets.main.jniLibs.srcDirs += 'libs/cdvnodejsmobile/libnode/bin/';
-
     String projectWWW; // www assets folder from the Application project.
     if ( file("${project.projectDir}/src/main/assets/www/").exists() ) {
         // www folder for cordova-android >= 7

--- a/src/android/build.gradle
+++ b/src/android/build.gradle
@@ -27,6 +27,7 @@ android {
 }
 
 import org.gradle.internal.os.OperatingSystem;
+import org.gradle.util.GradleVersion;
 
 cdvPluginPostBuildExtras += { ->
     if (android.defaultConfig.ndk.abiFilters == null) {
@@ -41,6 +42,10 @@ cdvPluginPostBuildExtras += { ->
     android.aaptOptions.ignoreAssetsPattern += ":!build-native-modules-MacOS-helper-script.sh";
     // The file that caches the value of NODEJS_MOBILE_BUILD_NATIVE_MODULES is not needed inside the APK.
     android.aaptOptions.ignoreAssetsPattern += ":!NODEJS_MOBILE_BUILD_NATIVE_MODULES_VALUE.txt";
+
+    if (GradleVersion.current() < GradleVersion.version("4.0")) {
+        android.sourceSets.main.jniLibs.srcDirs += 'libs/cdvnodejsmobile/libnode/bin/';
+    }
 
     String projectWWW; // www assets folder from the Application project.
     if ( file("${project.projectDir}/src/main/assets/www/").exists() ) {


### PR DESCRIPTION
To support Cordova 10, the following two fixes have been made.

- minSdkVersion 21 to 22
- Handling of jniLibs in Gradle 4

## minSdkVersion 21 to 22

Cordova Android 9 has been modified to reflect the change in minSdkVersion to 22.

> Android Version Support Update
> 
> - The default target SDK version is set to 29.
> - The minimum SDK version is set to 22.
> - The minimum supported Android version is 5.1.
> **NOTE** : because Cordova has increased the minimum SDK version to 22, we no longer support or test with Android 5.0 or lower.
> 
> https://cordova.apache.org/announcements/2020/06/29/cordova-android-9.0.0.html

## Handling of jniLibs in Gradle 4

Since Gradle 4.0, jniLibs has been removed as it is no longer needed.

refs: https://developer.android.com/studio/releases/gradle-plugin#cmake-imported-targets

Fix to check GradleVersion instead of simply deleting it.

### error message

```
> Task :app:mergeDebugNativeLibs FAILED

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':app:mergeDebugNativeLibs'.
> A failure occurred while executing com.android.build.gradle.internal.tasks.Workers$ActionFacade
   > More than one file was found with OS independent path 'lib/arm64-v8a/libnode.so'. If you are using jniLibs and CMake IMPORTED targets, see https://developer.android.com/studio/preview/features#automatic_packaging_of_prebuilt_dependencies_used_by_cmake

* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output. Run with --scan to get full insights.

* Get more help at https://help.gradle.org

Deprecated Gradle features were used in this build, making it incompatible with Gradle 7.0.
Use '--warning-mode all' to show the individual deprecation warnings.
See https://docs.gradle.org/6.5/userguide/command_line_interface.html#sec:command_line_warnings

BUILD FAILED in 20s
41 actionable tasks: 8 executed, 33 up-to-date
```