### PR TITLE
Fixed for Api.js specification changes in Cordova-Android@10

### DIFF
--- a/install/hooks/android/after-prepare-create-macOS-builder-helper.js
+++ b/install/hooks/android/after-prepare-create-macOS-builder-helper.js
@@ -14,7 +14,6 @@ function getPlatformWWWPath(context, platform) {
   return platformAPIInstance.locations.www;
 }
 
-
 // Adds a helper script to run "npm rebuild" with the current PATH.
 // This workaround is needed for Android Studio on macOS when it is not started
 // from the command line, as npm probably won't be in the PATH at build time.

--- a/install/hooks/android/after-prepare-create-macOS-builder-helper.js
+++ b/install/hooks/android/after-prepare-create-macOS-builder-helper.js
@@ -2,13 +2,18 @@ const fs = require('fs');
 const path = require('path');
 
 // Gets the platform's www path.
-function getPlatformWWWPath(context, platform)
-{
-  var platformPath = path.join(context.opts.projectRoot, 'platforms', platform);
-  var platformAPI = require(path.join(platformPath, 'cordova', 'Api'));
-  var platformAPIInstance = new platformAPI();
+function getPlatformWWWPath(context, platform) {
+  const platformPath = path.join(context.opts.projectRoot, 'platforms', platform);
+  const platformAPI = require(path.join(platformPath, 'cordova', 'Api'));
+  let platformAPIInstance;
+  try {
+    platformAPIInstance = new platformAPI();
+  } catch (e) {
+    platformAPIInstance = new platformAPI(platform, platformPath);
+  }
   return platformAPIInstance.locations.www;
 }
+
 
 // Adds a helper script to run "npm rebuild" with the current PATH.
 // This workaround is needed for Android Studio on macOS when it is not started

--- a/install/hooks/both/after-prepare-native-modules-preference.js
+++ b/install/hooks/both/after-prepare-native-modules-preference.js
@@ -2,11 +2,15 @@ const fs = require('fs');
 const path = require('path');
 
 // Gets the platform's www path.
-function getPlatformWWWPath(context, platform)
-{
-  var platformPath = path.join(context.opts.projectRoot, 'platforms', platform);
-  var platformAPI = require(path.join(platformPath, 'cordova', 'Api'));
-  var platformAPIInstance = new platformAPI();
+function getPlatformWWWPath(context, platform) {
+  const platformPath = path.join(context.opts.projectRoot, 'platforms', platform);
+  const platformAPI = require(path.join(platformPath, 'cordova', 'Api'));
+  let platformAPIInstance;
+  try {
+    platformAPIInstance = new platformAPI();
+  } catch (e) {
+    platformAPIInstance = new platformAPI(platform, platformPath);
+  }
   return platformAPIInstance.locations.www;
 }
 

--- a/install/hooks/both/after-prepare-patch-npm-packages.js
+++ b/install/hooks/both/after-prepare-patch-npm-packages.js
@@ -50,13 +50,17 @@ function visitPackageJSON(folderPath)
 }
 
 // Applies the patch to the selected platform
-function patchTargetPlatform(context, platform)
-{
-  var platformPath = path.join(context.opts.projectRoot, 'platforms', platform);
-  var platformAPI = require(path.join(platformPath, 'cordova', 'Api'));
-  var platformAPIInstance = new platformAPI();
-  var wwwPath = platformAPIInstance.locations.www;
-  var nodeModulesPathToPatch = path.join(wwwPath, 'nodejs-project', 'node_modules');
+function patchTargetPlatform(context, platform) {
+  const platformPath = path.join(context.opts.projectRoot, 'platforms', platform);
+  const platformAPI = require(path.join(platformPath, 'cordova', 'Api'));
+  let platformAPIInstance;
+  try {
+    platformAPIInstance = new platformAPI();
+  } catch (e) {
+    platformAPIInstance = new platformAPI(platform, platformPath);
+  }
+  const wwwPath = platformAPIInstance.locations.www;
+  const nodeModulesPathToPatch = path.join(wwwPath, 'nodejs-project', 'node_modules');
   if (fs.existsSync(nodeModulesPathToPatch)) {
     visitPackageJSON(nodeModulesPathToPatch);
   }


### PR DESCRIPTION
In Cordova-Android@10, Api.js now has an argument.
For compatibility, I propose to support this with try/catch.